### PR TITLE
Set dark theme default

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import {
   Sidebar,
   SidebarInset,
 } from "@/components/ui/sidebar";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,27 +31,27 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <SidebarProvider>
-          <div className="flex min-h-screen flex-col md:flex-row">
-            <Sidebar>
-              <nav className="flex flex-col space-y-2 p-4">
-                <Link href="/" className="hover:underline">
-                  Home
-                </Link>
-                <Link href="#" className="hover:underline">
-                  About
-                </Link>
-                <Link href="#" className="hover:underline">
-                  Contact
-                </Link>
-              </nav>
-            </Sidebar>
-            <SidebarInset>{children}</SidebarInset>
-          </div>
-        </SidebarProvider>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider>
+          <SidebarProvider>
+            <div className="flex min-h-screen flex-col md:flex-row">
+              <Sidebar>
+                <nav className="flex flex-col space-y-2 p-4">
+                  <Link href="/" className="hover:underline">
+                    Home
+                  </Link>
+                  <Link href="#" className="hover:underline">
+                    About
+                  </Link>
+                  <Link href="#" className="hover:underline">
+                    Contact
+                  </Link>
+                </nav>
+              </Sidebar>
+              <SidebarInset>{children}</SidebarInset>
+            </div>
+          </SidebarProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import type { ThemeProviderProps } from "next-themes"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="dark" {...props}>
+      {children}
+    </NextThemesProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `ThemeProvider` component
- wrap layout with `ThemeProvider` so the default theme is dark

## Testing
- `npm run lint`
- `npm run build` *(fails: Property 'payload' does not exist on type in chart.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_686c6cc0cd1c83278ce872355dee5b29