### PR TITLE
Add session-based login system

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { authenticate } from '@/lib/auth'
+
+export async function POST(request: NextRequest) {
+  const { username, password } = await request.json()
+  if (authenticate(username, password)) {
+    const response = NextResponse.json({ success: true })
+    response.cookies.set('session', 'authenticated', {
+      httpOnly: true,
+      path: '/',
+    })
+    return response
+  }
+  return NextResponse.json({ success: false }, { status: 401 })
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,54 @@
+"use client"
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [redirectTo, setRedirectTo] = useState('/')
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const next = params.get('next')
+    if (next) setRedirectTo(next)
+  }, [])
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    if (res.ok) {
+      router.push(redirectTo)
+    } else {
+      setError('Invalid credentials')
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+        <h1 className="text-2xl font-semibold text-center">Login</h1>
+        <Input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <Button type="submit" className="w-full">Sign In</Button>
+      </form>
+    </div>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,3 @@
+export function authenticate(username: string, password: string): boolean {
+  return username === 'admin' && password === 'admin';
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl
+
+  if (pathname.startsWith('/_next') || pathname.startsWith('/api') || pathname === '/login') {
+    return NextResponse.next()
+  }
+
+  const session = request.cookies.get('session')?.value
+  if (!session) {
+    const loginUrl = new URL('/login', request.url)
+    loginUrl.searchParams.set('next', pathname + search)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: '/:path*'
+}


### PR DESCRIPTION
## Summary
- create authentication helper
- add login API endpoint
- implement `/login` page
- protect pages via middleware

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c72c29d7c8327bf5136d41d018cec