### PR TITLE
Hide sidebar on login page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
+"use client"
 import type { Metadata } from "next";
+import { usePathname } from "next/navigation";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Link from "next/link";
@@ -38,44 +40,53 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const pathname = usePathname()
+  const showSidebar = pathname !== "/login"
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ThemeProvider>
           <SidebarProvider>
-            <div className="flex min-h-screen w-full flex-col md:flex-row">
-              <Sidebar>
-                <nav className="flex flex-col space-y-2 p-4">
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="/">
-                      <BookIcon className="mr-2" /> Home
-                    </Link>
-                  </Button>
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="#">
-                      <UsersIcon className="mr-2" /> Authors
-                    </Link>
-                  </Button>
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="#">
-                      <InfoIcon className="mr-2" /> About
-                    </Link>
-                  </Button>
-                  <Separator className="my-2" />
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="#">
-                      <SettingsIcon className="mr-2" /> Settings
-                    </Link>
-                  </Button>
-                </nav>
-              </Sidebar>
-              <SidebarInset>
-                <div className="flex min-h-screen w-full flex-1 flex-col">
-                  {children}
-                  <Footer />
-                </div>
-              </SidebarInset>
-            </div>
+            {showSidebar ? (
+              <div className="flex min-h-screen w-full flex-col md:flex-row">
+                <Sidebar>
+                  <nav className="flex flex-col space-y-2 p-4">
+                    <Button asChild variant="ghost" className="justify-start">
+                      <Link href="/">
+                        <BookIcon className="mr-2" /> Home
+                      </Link>
+                    </Button>
+                    <Button asChild variant="ghost" className="justify-start">
+                      <Link href="#">
+                        <UsersIcon className="mr-2" /> Authors
+                      </Link>
+                    </Button>
+                    <Button asChild variant="ghost" className="justify-start">
+                      <Link href="#">
+                        <InfoIcon className="mr-2" /> About
+                      </Link>
+                    </Button>
+                    <Separator className="my-2" />
+                    <Button asChild variant="ghost" className="justify-start">
+                      <Link href="#">
+                        <SettingsIcon className="mr-2" /> Settings
+                      </Link>
+                    </Button>
+                  </nav>
+                </Sidebar>
+                <SidebarInset>
+                  <div className="flex min-h-screen w-full flex-1 flex-col">
+                    {children}
+                    <Footer />
+                  </div>
+                </SidebarInset>
+              </div>
+            ) : (
+              <div className="flex min-h-screen w-full flex-col">
+                {children}
+                <Footer />
+              </div>
+            )}
           </SidebarProvider>
         </ThemeProvider>
       </body>


### PR DESCRIPTION
## Summary
- show the sidebar on all pages except `/login`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c74cbe2688327b992a534da410fa1