### PR TITLE
Fix sidebar skeleton hydration mismatch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 "use client"
-import { usePathname } from "next/navigation";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Link from "next/link";
@@ -34,8 +33,6 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const pathname = usePathname()
-  const showSidebar = pathname !== "/login"
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -606,9 +606,12 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
+  const [width, setWidth] = React.useState<string>()
+
+  // Random width between 50 to 90% only on the client to avoid
+  // rendering mismatches during hydration.
+  React.useEffect(() => {
+    setWidth(`${Math.floor(Math.random() * 40) + 50}%`)
   }, [])
 
   return (
@@ -629,7 +632,7 @@ function SidebarMenuSkeleton({
         data-sidebar="menu-skeleton-text"
         style={
           {
-            "--skeleton-width": width,
+            "--skeleton-width": width ?? "100%",
           } as React.CSSProperties
         }
       />


### PR DESCRIPTION
## Summary
- fix hydration errors by computing skeleton width on the client
- remove an unused variable in the layout to pass lint

## Testing
- `npm run lint`
- `npm run dev` (started and ran without hydration errors)

------
https://chatgpt.com/codex/tasks/task_e_686c7c2dcbf083278f3d5f7c2cce48e5