### PR TITLE
Add mobile navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import {
   Sidebar,
   SidebarInset,
 } from "@/components/ui/sidebar";
+import MobileNavbar from "@/components/MobileNavbar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -70,6 +71,7 @@ export default function RootLayout({
                 </nav>
               </Sidebar>
               <SidebarInset>
+                <MobileNavbar />
                 <div className="flex min-h-screen w-full flex-1 flex-col">
                   {children}
                   <Footer />

--- a/components/MobileNavbar.tsx
+++ b/components/MobileNavbar.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import Link from "next/link"
+import { SidebarTrigger, useSidebar } from "@/components/ui/sidebar"
+
+export default function MobileNavbar() {
+  const { isMobile } = useSidebar()
+
+  if (!isMobile) {
+    return null
+  }
+
+  return (
+    <header className="md:hidden flex items-center gap-2 border-b p-4">
+      <SidebarTrigger />
+      <Link href="/" className="text-base font-semibold">
+        Alexandria
+      </Link>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- create `MobileNavbar` component that shows a sidebar toggle on mobile
- include mobile navbar in main layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Route `app/api/books/[id]/route.ts` invalid `GET` export)*

------
https://chatgpt.com/codex/tasks/task_e_686c7e5ad5f883278188f789efb90abb