### PR TITLE
Persist search query in URL

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,11 +9,32 @@ import { Toaster } from "@/components/ui/sonner"
 import { toast } from "sonner"
 import type { Book } from "@/lib/bookSearch"
 import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
 
 export default function Home() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
   const [query, setQuery] = React.useState("")
   const [books, setBooks] = React.useState<Book[] | null>(null)
   const [loading, setLoading] = React.useState(false)
+
+  React.useEffect(() => {
+    const q = searchParams.get('q')
+    if (q !== null) {
+      setQuery(q)
+      setLoading(true)
+      fetch(`/api/books/search?q=${encodeURIComponent(q)}`)
+        .then((res) => res.json())
+        .then((data) => setBooks(data.books))
+        .catch((err) => {
+          console.error(err)
+          setBooks([])
+        })
+        .finally(() => setLoading(false))
+    } else {
+      setBooks(null)
+    }
+  }, [searchParams])
 
   async function handleAdd(book: Book) {
     await fetch('/api/favourites', {
@@ -26,17 +47,7 @@ export default function Home() {
 
   async function handleSearch(e: React.FormEvent) {
     e.preventDefault()
-    setLoading(true)
-    try {
-      const res = await fetch(`/api/books/search?q=${encodeURIComponent(query)}`)
-      const data = await res.json()
-      setBooks(data.books)
-    } catch (err) {
-      console.error(err)
-      setBooks([])
-    } finally {
-      setLoading(false)
-    }
+    router.push(`/?q=${encodeURIComponent(query)}`)
   }
 
   return (


### PR DESCRIPTION
## Summary
- store current search query in the URL
- auto-run searches when query parameter is present

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c7f12a1cc8327809c6175ee42bec5