### PR TITLE
Improve book detail page

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -1,38 +1,157 @@
 import { getBook } from '@/lib/bookSearch'
 import { notFound } from 'next/navigation'
 import BackButton from '@/components/BackButton'
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs'
+import {
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableHead,
+} from '@/components/ui/table'
+import { Progress } from '@/components/ui/progress'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { AspectRatio } from '@/components/ui/aspect-ratio'
+import Image from 'next/image'
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip'
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbSeparator,
+  BreadcrumbLink,
+  BreadcrumbPage,
+} from '@/components/ui/breadcrumb'
 
 export default async function BookPage({ params }: { params: { id: string } }) {
   const book = await getBook(Number(params.id))
   if (!book) return notFound()
   return (
-    <div className="relative flex min-h-screen flex-col items-center p-8 pt-12">
+    <div className="relative flex min-h-screen flex-col">
       <BackButton className="absolute left-4 top-4" />
-      <Card className="w-full max-w-xl">
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            {book.title}
-            {book.year && (
-              <Badge variant="secondary" className="ml-2">
-                {book.year}
-              </Badge>
-            )}
-          </CardTitle>
-          {book.author && <CardDescription>{book.author}</CardDescription>}
-        </CardHeader>
-        {book.description && (
-          <CardContent className="pt-0 pb-4">
-            <p className="text-sm text-muted-foreground">{book.description}</p>
+      <Breadcrumb className="px-8 pt-8">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{book.title}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <ScrollArea className="flex-1 p-8">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              {book.title}
+              {book.year && (
+                <Badge variant="secondary" className="ml-2">
+                  {book.year}
+                </Badge>
+              )}
+            </CardTitle>
+            {book.author && <CardDescription>{book.author}</CardDescription>}
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <AspectRatio ratio={16 / 9} className="bg-muted">
+              <Image
+                src={`https://source.unsplash.com/featured/?book,${book.title}`}
+                alt="Book cover"
+                fill
+                className="rounded-md object-cover"
+              />
+            </AspectRatio>
+            <Tabs defaultValue="summary" className="w-full">
+              <TabsList>
+                <TabsTrigger value="summary">Summary</TabsTrigger>
+                <TabsTrigger value="details">Details</TabsTrigger>
+              </TabsList>
+              <Separator className="my-4" />
+              <TabsContent value="summary" className="space-y-4">
+                {book.description && (
+                  <p className="text-sm text-muted-foreground">
+                    {book.description}
+                  </p>
+                )}
+                {book.rating && (
+                  <div className="space-y-2">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge variant="outline">
+                          Rating: {book.rating.toFixed(1)}
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>Out of 5</TooltipContent>
+                    </Tooltip>
+                    <Progress value={(book.rating / 5) * 100} />
+                  </div>
+                )}
+              </TabsContent>
+              <TabsContent value="details">
+                <Table>
+                  <TableBody>
+                    {book.genre && (
+                      <TableRow>
+                        <TableHead>Genre</TableHead>
+                        <TableCell>{book.genre}</TableCell>
+                      </TableRow>
+                    )}
+                    {book.pages && (
+                      <TableRow>
+                        <TableHead>Pages</TableHead>
+                        <TableCell>{book.pages}</TableCell>
+                      </TableRow>
+                    )}
+                    {book.publisher && (
+                      <TableRow>
+                        <TableHead>Publisher</TableHead>
+                        <TableCell>{book.publisher}</TableCell>
+                      </TableRow>
+                    )}
+                    {book.language && (
+                      <TableRow>
+                        <TableHead>Language</TableHead>
+                        <TableCell>{book.language}</TableCell>
+                      </TableRow>
+                    )}
+                    {book.isbn && (
+                      <TableRow>
+                        <TableHead>ISBN</TableHead>
+                        <TableCell>{book.isbn}</TableCell>
+                      </TableRow>
+                    )}
+                    {book.year && (
+                      <TableRow>
+                        <TableHead>Year</TableHead>
+                        <TableCell>{book.year}</TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </TabsContent>
+            </Tabs>
           </CardContent>
-        )}
-        {book.rating && (
-          <CardContent className="pt-0">
-            <Badge variant="outline">Rating: {book.rating.toFixed(1)}</Badge>
-          </CardContent>
-        )}
-      </Card>
+        </Card>
+      </ScrollArea>
     </div>
   )
 }

--- a/lib/bookSearch.ts
+++ b/lib/bookSearch.ts
@@ -5,6 +5,11 @@ export interface Book {
   year?: number
   description?: string
   rating?: number
+  genre?: string
+  pages?: number
+  publisher?: string
+  language?: string
+  isbn?: string
 }
 
 /**
@@ -20,6 +25,11 @@ export const books: Book[] = [
     description:
       "A story of the mysteriously wealthy Jay Gatsby and his love for Daisy Buchanan during the Roaring Twenties.",
     rating: 4.4,
+    genre: "Novel",
+    pages: 218,
+    publisher: "Charles Scribner's Sons",
+    language: "English",
+    isbn: "9780743273565",
   },
   {
     id: 2,
@@ -29,6 +39,11 @@ export const books: Book[] = [
     description:
       "A romantic novel that charts the emotional development of Elizabeth Bennet, who learns about the repercussions of hasty judgments.",
     rating: 4.6,
+    genre: "Romance",
+    pages: 279,
+    publisher: "T. Egerton, Whitehall",
+    language: "English",
+    isbn: "9780199535569",
   },
   {
     id: 3,
@@ -38,6 +53,11 @@ export const books: Book[] = [
     description:
       "A novel about the serious issues of rape and racial inequality told through the eyes of a young girl in the Deep South.",
     rating: 4.8,
+    genre: "Southern Gothic",
+    pages: 281,
+    publisher: "J.B. Lippincott & Co.",
+    language: "English",
+    isbn: "9780061120084",
   },
   {
     id: 4,
@@ -47,6 +67,11 @@ export const books: Book[] = [
     description:
       "A dystopian social science fiction novel and cautionary tale about the dangers of totalitarianism.",
     rating: 4.7,
+    genre: "Dystopian",
+    pages: 328,
+    publisher: "Secker & Warburg",
+    language: "English",
+    isbn: "9780451524935",
   },
   {
     id: 5,
@@ -56,6 +81,11 @@ export const books: Book[] = [
     description:
       "The narrative of Captain Ahab's obsessive quest to seek revenge on the white whale that bit off his leg.",
     rating: 4.2,
+    genre: "Adventure",
+    pages: 585,
+    publisher: "Harper & Brothers",
+    language: "English",
+    isbn: "9781503280786",
   },
   {
     id: 6,
@@ -65,6 +95,11 @@ export const books: Book[] = [
     description:
       "An epic novel that intertwines the lives of private and public individuals during the time of the Napoleonic wars.",
     rating: 4.5,
+    genre: "Historical",
+    pages: 1225,
+    publisher: "The Russian Messenger",
+    language: "Russian",
+    isbn: "9780199232765",
   },
 ]
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -15,6 +15,11 @@ CREATE TABLE IF NOT EXISTS favourites (
   year INTEGER,
   description TEXT,
   rating REAL,
+  genre TEXT,
+  pages INTEGER,
+  publisher TEXT,
+  language TEXT,
+  isbn TEXT,
   UNIQUE(username, book_id)
 )`
 
@@ -22,7 +27,20 @@ db.exec(init)
 
 export function addFavourite(username: string, book: Book) {
   const stmt = db.prepare(
-    `INSERT OR IGNORE INTO favourites (username, book_id, title, author, year, description, rating) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    `INSERT OR IGNORE INTO favourites (
+      username,
+      book_id,
+      title,
+      author,
+      year,
+      description,
+      rating,
+      genre,
+      pages,
+      publisher,
+      language,
+      isbn
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
   stmt.run(
     username,
@@ -31,7 +49,12 @@ export function addFavourite(username: string, book: Book) {
     book.author ?? null,
     book.year ?? null,
     book.description ?? null,
-    book.rating ?? null
+    book.rating ?? null,
+    book.genre ?? null,
+    book.pages ?? null,
+    book.publisher ?? null,
+    book.language ?? null,
+    book.isbn ?? null
   )
 }
 
@@ -44,7 +67,19 @@ export function removeFavourite(username: string, bookId: number) {
 
 export function getFavourites(username: string): Book[] {
   const stmt = db.prepare(
-    `SELECT book_id as id, title, author, year, description, rating FROM favourites WHERE username = ?`
+    `SELECT
+      book_id as id,
+      title,
+      author,
+      year,
+      description,
+      rating,
+      genre,
+      pages,
+      publisher,
+      language,
+      isbn
+    FROM favourites WHERE username = ?`
   )
   return stmt.all(username) as Book[]
 }


### PR DESCRIPTION
## Summary
- enrich `Book` interface with more metadata
- update SQLite table and queries for new columns
- overhaul book details page with breadcrumb, tabs, table and other UI components

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c7f6d769083278a86a165b461cb91