### PR TITLE
Add search loading animation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import React from "react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { Loader2 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -66,13 +67,14 @@ export default function Home() {
 
   return (
     <>
-    <div
-      className={`flex min-h-screen flex-col items-center p-8 ${
-        books ? "pt-12" : "justify-center"
-      }`}
-    >
+    <div className="flex min-h-screen flex-col items-center p-8 pt-12">
       <h1 className="mb-6 text-3xl font-semibold">Book Search</h1>
-      <form onSubmit={handleSearch} className="w-full max-w-md mb-8 space-y-2">
+      <form
+        onSubmit={handleSearch}
+        className={`w-full max-w-md mb-8 space-y-2 transition-transform duration-500 ${
+          books === null && !loading ? "translate-y-[40vh]" : ""
+        }`}
+      >
         <div className="flex gap-2">
           <Input
             placeholder="Search books..."
@@ -81,12 +83,13 @@ export default function Home() {
             className="flex-1"
           />
           <Button type="submit" disabled={loading}>
+            {loading && <Loader2 className="size-4 animate-spin" />} 
             {loading ? "Searching..." : "Search"}
           </Button>
         </div>
       </form>
       {books && (
-        <div className="w-full max-w-xl space-y-4">
+        <div className="w-full max-w-xl space-y-4 animate-in fade-in">
           {books.length === 0 && (
             <Alert>
               <AlertDescription>No results found.</AlertDescription>


### PR DESCRIPTION
## Summary
- show a spinner in the search button when searching
- animate the search bar into place
- fade search results in when shown

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c830985388327bfc3f7d4c2b40358