### PR TITLE
Use breadcrumb to navigate back

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { getBook } from '@/lib/bookSearch'
 import { notFound } from 'next/navigation'
-import BackButton from '@/components/BackButton'
+import BackBreadcrumb from '@/components/BackBreadcrumb'
 import {
   Card,
   CardContent,
@@ -29,7 +29,6 @@ import {
   BreadcrumbList,
   BreadcrumbItem,
   BreadcrumbSeparator,
-  BreadcrumbLink,
   BreadcrumbPage,
 } from '@/components/ui/breadcrumb'
 
@@ -38,11 +37,10 @@ export default async function BookPage({ params }: { params: { id: string } }) {
   if (!book) return notFound()
   return (
     <div className="relative flex min-h-screen flex-col">
-      <BackButton className="absolute left-4 top-4" />
       <Breadcrumb className="px-8 pt-8">
         <BreadcrumbList>
           <BreadcrumbItem>
-            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+            <BackBreadcrumb />
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>

--- a/components/BackBreadcrumb.tsx
+++ b/components/BackBreadcrumb.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
+import { BreadcrumbLink } from "@/components/ui/breadcrumb"
+
+export default function BackBreadcrumb({
+  children = "Back",
+}: {
+  children?: React.ReactNode
+}) {
+  const router = useRouter()
+  return (
+    <BreadcrumbLink asChild>
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="size-3" />
+        {children}
+      </button>
+    </BreadcrumbLink>
+  )
+}


### PR DESCRIPTION
## Summary
- add `BackBreadcrumb` component for navigating with breadcrumbs
- remove `BackButton` usage in book details page and include new breadcrumb link

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c874d377c8327853f637565cacfb8