### PR TITLE
Show cover images on search

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ import { toast } from "sonner"
 import type { Book } from "@/lib/bookSearch"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
+import { AspectRatio } from "@/components/ui/aspect-ratio"
+import Image from "next/image"
 
 export default function Home() {
   const router = useRouter()
@@ -120,6 +122,18 @@ export default function Home() {
                   <CardDescription>{book.author}</CardDescription>
                 )}
               </CardHeader>
+              {typeof book.cover_i === 'number' && (
+                <CardContent className="pt-0">
+                  <AspectRatio ratio={16 / 9} className="bg-muted">
+                    <Image
+                      src={`https://covers.openlibrary.org/b/id/${book.cover_i}.jpg`}
+                      alt="Book cover"
+                      fill
+                      className="rounded-md object-cover"
+                    />
+                  </AspectRatio>
+                </CardContent>
+              )}
               {book.description && (
                 <CardContent className="pt-0">
                   <p className="text-sm text-muted-foreground">

--- a/lib/bookSearch.ts
+++ b/lib/bookSearch.ts
@@ -10,6 +10,7 @@ export interface Book {
   publisher?: string
   language?: string
   isbn?: string
+  cover_i?: number
 }
 
 interface OpenLibraryDoc {
@@ -142,6 +143,10 @@ export async function searchBooks(query: string): Promise<Book[]> {
       const book: Book = {
         id: idMatch ? Number(idMatch[0]) : idx,
         title: doc.title ?? 'Unknown',
+      }
+
+      if (typeof doc.cover_i === 'number') {
+        book.cover_i = doc.cover_i
       }
 
       if (Array.isArray(doc.author_name) && doc.author_name.length > 0) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,12 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "covers.openlibrary.org",
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- extend `Book` type with `cover_i`
- capture `cover_i` from OpenLibrary results
- allow images from `covers.openlibrary.org`
- show book covers on the search results page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c8e343aa8832794afb339a0f18ee7